### PR TITLE
Add Reddit engagement scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Semplice applicazione web per analizzare una stock e stimarne il fair value.
 L'app usa [Flask](https://flask.palletsprojects.com/) e recupera i dati da
 [Yahoo Finance](https://finance.yahoo.com/) tramite la libreria `yfinance`.
-Inoltre legge alcuni post da Reddit per calcolare un punteggio di sentiment.
+Inoltre legge post da più subreddit Reddit per calcolare un punteggio di sentiment
+e un indicatore di engagement complessivo.
 
 ## Requisiti
 - Python 3.8+
@@ -39,7 +40,8 @@ L'app sarà disponibile su `http://localhost:5000`.
 ## Funzionalità
 - Inserimento ticker e analisi dei dati storici degli ultimi 5 anni.
 - Calcolo di un valore equo semplificato basato su media storica e multipli.
-- Analisi del sentiment Reddit (numero di post e media del punteggio VADER).
+- Analisi del sentiment Reddit su più subreddit con calcolo di engagement e
+  social score.
 - Interfaccia minimale con animazione di fade‑in.
 
 Questa è una base di partenza per creare uno strumento più avanzato.

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,6 +27,8 @@
         <div class="sentiment">
             <h3>Sentiment Reddit ({{ sentiment.count }} post)</h3>
             <p>Punteggio medio: {{ sentiment.sentiment | round(2) }}</p>
+            <p>Engagement totale: {{ sentiment.engagement }}</p>
+            <p class="fair">Social score: {{ sentiment.score | round(2) }}</p>
         </div>
         {% endif %}
     </div>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,6 +2,7 @@ import os, sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import app
 from unittest.mock import patch
+import numpy as np
 
 
 def test_get_index():
@@ -21,9 +22,32 @@ def test_post_index(mock_fair, mock_sentiment):
         'pb_ratio': 1,
         'fair_value': 9.5,
     }
-    mock_sentiment.return_value = {'count': 5, 'sentiment': 0.1}
+    mock_sentiment.return_value = {
+        'count': 5,
+        'sentiment': 0.1,
+        'engagement': 12,
+        'score': 0.5,
+    }
     client = app.app.test_client()
     resp = client.post('/', data={'ticker': 'AAPL'})
     assert resp.status_code == 200
     assert b"Fair value stimato" in resp.data
     mock_fair.assert_called_once_with('AAPL')
+
+
+@patch.object(app.analyzer, 'polarity_scores')
+@patch.object(app, 'reddit')
+def test_reddit_sentiment_algorithm(mock_reddit, mock_polarity):
+    post = type('Post', (), {'title': 'x', 'score': 10, 'num_comments': 2})
+    post2 = type('Post', (), {'title': 'y', 'score': 5, 'num_comments': 1})
+    mock_reddit.subreddit.return_value.search.return_value = [post, post2]
+    mock_polarity.side_effect = [{'compound': 0.5}, {'compound': -0.3}] * 3
+
+    result = app.reddit_sentiment('AAPL')
+    assert result['count'] == 6
+    assert round(result['sentiment'], 2) == 0.10
+    assert result['engagement'] == 54
+    expected_score = 0.1 * np.log1p(54)
+    assert abs(result['score'] - expected_score) < 1e-6
+
+


### PR DESCRIPTION
## Summary
- enrich Reddit analysis with engagement data from multiple subreddits
- show engagement and social score in the UI
- document new social sentiment features in the README
- test engagement computation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cc101593c832cbc195e616c165a49